### PR TITLE
fix: change launchpad wrapper width on visibility change

### DIFF
--- a/runtime/launchpad/index.js
+++ b/runtime/launchpad/index.js
@@ -52,6 +52,7 @@ export class LaunchpadRuntime extends Component {
       window.removeEventListener('orientationchange', this.setViewportWidth)
     } else {
       setTimeout(() => {
+        this.setViewportWidth()
         window.addEventListener('resize', this.setViewportWidth, false)
         window.addEventListener('orientationchange', this.setViewportWidth, false)
       }, REBOUND)


### PR DESCRIPTION
When minimising the browser, changing orientation and returning to the browser, the launchpad runtime didn't have the correct width, hence setting it on the visibility change event callback. Not sure if this change would be useful on the trails runtime as well? @dariocravero 