### PR TITLE
fix: remove focus reset

### DIFF
--- a/runtime/base-style.js
+++ b/runtime/base-style.js
@@ -26,7 +26,6 @@ export default props => (
           flex-shrink: 0;
       margin: 0;
       padding: 0;
-      outline: 0;
     }
     button,a {
       background-color: transparent;


### PR DESCRIPTION
Removed the focus outline reset, to enable default browser focus styling. Required for accessibility