### PR TITLE
feat: make Svg block non-focusable unless explicitly overridden via p…

### DIFF
--- a/blocks/svg.js
+++ b/blocks/svg.js
@@ -1,7 +1,7 @@
 import React from 'react'
 
 const Svg = ({ children, ...props }) => (
-  <svg {...props}>
+  <svg focusable={props.focusable || false} {...props}>
     {children}
   </svg>
 )


### PR DESCRIPTION
…rops

We ran into an issue with RCE where SVGs are inserted into the tab order on IE11 and thus get focus when the user tabs through the page. First attempt at a fix was manually setting the `focusable="false"` flag on each instance of the `<Svg>` block - the proposed fix here would be more efficient; defaulting the Svg block to non-focusable unless overridden by explicitly passing in the prop (just on the off-chance somebody has a use case for a focusable svg) 