### PR TITLE
chore: bump react-dom version to >=16.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "mini-unique-id": "^1.0.1",
     "prop-types": "^15.5.10",
     "react": "^16.0.0",
-    "react-dom": "^16.0.0",
+    "react-dom": ">=16.2.1",
     "react-redux": "^5.0.5",
     "redux": "^3.5.2",
     "redux-thunk": "^2.1.0",


### PR DESCRIPTION
Requesting bump of Panels `react-dom` version to address automated security vulnerability alert raised by Github for the RCE repo 